### PR TITLE
Update error handling

### DIFF
--- a/libs/xevlabs-strapi-error-handling/src/lib/services/error-http-interceptor.service.ts
+++ b/libs/xevlabs-strapi-error-handling/src/lib/services/error-http-interceptor.service.ts
@@ -20,7 +20,7 @@ export class ErrorHttpInterceptorService implements HttpInterceptor {
             map(result => result),
             catchError((error: any) => {
                 if (error instanceof HttpErrorResponse) {
-                    return this.handleError(error);
+                    return this.handleError(error.error);
                 } else {
                     return throwError(error);
                 }


### PR DESCRIPTION
there was a problem with the error object being passed not having the proper format and so there were no snackbars showing for most errors